### PR TITLE
[Feat] Themed / Monochrome launcher app icon

### DIFF
--- a/app/src/main/res/mipmap/ic_launcher.xml
+++ b/app/src/main/res/mipmap/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
   <background android:drawable="@color/launcher_background" />
   <foreground android:drawable="@drawable/ic_launcher_foreground" />
+  <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
This PR adds support for themed launcher icon.
See [this](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive), section on "User theming" for reference.

Preview:

- Mint Green

  - Light Theme
    
    <img src="https://github.com/user-attachments/assets/5ef7c515-b056-45f3-a335-53e097fc0a0c" width="50%">
  - Dark Theme

    <img src="https://github.com/user-attachments/assets/5567540c-e13a-4414-8434-7913216b3407" width="50%">

